### PR TITLE
fix(rbx): faucet fails for round amounts (10, 100) — scientific notation in SendTransaction URL

### DIFF
--- a/rbx/client.py
+++ b/rbx/client.py
@@ -1047,8 +1047,10 @@ def get_default_vbtc_base64_image_data():
 def send_testnet_funds(from_address: str, to_address: str, amount: Decimal):
 
     if settings.FAUCET_ENABLED:
-        # Strip trailing zeros from amount (e.g., 1.0 -> "1", 1.10000 -> "1.1")
-        amount_str = str(amount.normalize())
+        # Strip trailing zeros (1.0 -> "1", 1.10000 -> "1.1") without the
+        # scientific notation str(normalize()) produces for round numbers
+        # (10 -> "1E+1"), which the CLI can't parse.
+        amount_str = format(amount.normalize(), "f")
         url = join_url(
             BASE_URL, f"api/V1/SendTransaction/{from_address}/{to_address}/{amount_str}"
         )


### PR DESCRIPTION
## What
One-line fix: format the faucet send amount with `format(amount.normalize(), 'f')` instead of `str(amount.normalize())`.

## Why
`Decimal('10').normalize()` stringifies as `1E+1` (same for 100 → `1E+2`, 1000 → `1E+3`), so the CLI's `SendTransaction/{from}/{to}/{amount}` URL got scientific notation it can't parse and answered FAIL → `{"message":"Failed to request funds."}`. Amounts without trailing zeros (5, 12.5) worked, which made it look intermittent. Confirmed empirically: requesting 5 succeeded, 10 failed.

`format(..., 'f')` keeps the intended trailing-zero stripping (1.0 → "1", 1.10000 → "1.1") but renders round numbers plainly (10 → "10").

## Testing
Verified the formatting for 1.0, 5, 10, 100, 1000, 1.10000, 0.0001, 12.5 locally; end-to-end verify on testnet after merge (request 10 VFX through the faucet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)